### PR TITLE
Add language settings

### DIFF
--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -25,7 +25,7 @@ RUN cd /tmp && \
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8
 
 # Install dependencies from pip
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -25,7 +25,7 @@ RUN cd /tmp && \
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 LANG=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Install dependencies from pip
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+


### PR DESCRIPTION
*Issue #, if available:*

We can not handle multibyte characters well with the SKlearn container.

*Description of changes:*

- Add language settings
    - Looks like [TensorFlow](https://github.com/aws/sagemaker-tensorflow-container/blob/script-mode/docker/1.13.1/Dockerfile.cpu#L67)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
