### PR TITLE
Using CodeBuild /aws/codebuild/standard:2.0 build image

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -1,6 +1,9 @@
 version: 0.2
 
 phases:
+  install:
+    runtime-versions:
+      docker: 18
   pre_build:
     commands:
     - echo Logging in to Amazon ECR...

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -4,6 +4,7 @@ phases:
   install:
     runtime-versions:
       docker: 18
+      python: 3.7
   pre_build:
     commands:
     - echo Logging in to Amazon ECR...

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -14,6 +14,7 @@ phases:
     - echo Build started on `date`
     - echo Building the Docker image...
     - docker build -t sklearn-base:0.20.0-cpu-py3  -f docker/0.20.0/base/Dockerfile.cpu --build-arg py_version=3 .
+    - pip install wheel setuptools
     - python setup.py bdist_wheel
     - docker build -t preprod-sklearn:0.20.0-cpu-py3 -f docker/0.20.0/final/Dockerfile.cpu --build-arg py_version=3 .
     - docker tag preprod-sklearn:0.20.0-cpu-py3 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -29,4 +29,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 
 # Install dependencies from pip
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+
-RUN pip install --no-cache -I scikit-learn==0.20.0 retrying wheel setuptools
+RUN pip install --no-cache -I scikit-learn==0.20.0 retrying

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -29,4 +29,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 
 # Install dependencies from pip
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+
-RUN pip install --no-cache -I scikit-learn==0.20.0 retrying
+RUN pip install --no-cache -I scikit-learn==0.20.0 retrying wheel setuptools


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upgrading CodeBuild to standard:2.0, which requires runtime-install specifications in buildspec.yml file.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
