### PR TITLE
Fix path to SageMaker SKLearn git repository in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,8 +132,8 @@ dependencies.
 
 ::
 
-    git clone https://github.com/aws/sagemaker-sklearn-container.git
-    cd sagemaker-sklearn-container
+    git clone https://github.com/aws/sagemaker-scikit-learn-container.git
+    cd sagemaker-scikit-learn-container
     pip install -e .[test]
 
 Tests are defined in


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix path to SageMaker SKLearn git repository in documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
