### PR TITLE
Skip downloading user modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.2.0', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.5.5', 'scikit-learn>=0.20.0', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']


### PR DESCRIPTION
*Issue #, if available:*

AWSMLC-19

*Description of changes:*

With the current setup, each GUnicorn workers will try to run `python3 -m pip install`:

![image](https://user-images.githubusercontent.com/6236795/64002785-be31a680-cabf-11e9-8c9d-fccf711046b6.png)

This PR checks if the user module exists and skips installation if it does (`sagemaker_containers.modules.import_module` will download and run `pip install`). There was a change in [sagemaker-containers](https://github.com/aws/sagemaker-containers/commit/8ad2c32c60ccb9e6d50e5e0afed38954164e709e), which makes it no longer necessary to import the user module before the process starts, and if there was an entry point script, the module will have been installed by the time we get to `try...except...`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
