### PR TITLE
Integrate ML-IO library and apache arrow

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -13,10 +13,10 @@ phases:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
-    - docker build -t sklearn-base:0.20.0-cpu-py3  -f docker/0.20.0/base/Dockerfile.cpu --build-arg py_version=3 .
+    - docker build -t sklearn-base:0.20.0-cpu-py3  -f docker/0.20.0/base/Dockerfile.cpu .
     - pip install wheel setuptools
     - python setup.py bdist_wheel
-    - docker build -t preprod-sklearn:0.20.0-cpu-py3 -f docker/0.20.0/final/Dockerfile.cpu --build-arg py_version=3 .
+    - docker build -t preprod-sklearn:0.20.0-cpu-py3 -f docker/0.20.0/final/Dockerfile.cpu .
     - docker tag preprod-sklearn:0.20.0-cpu-py3 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3
   post_build:
     commands:

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -1,32 +1,24 @@
 FROM ubuntu:16.04
 
-ARG py_version
-
-# Validate that arguments are specified
-RUN test $py_version || exit 1
-
 # Install python and other scikit-learn runtime dependencies
 # Dependency list from http://scikit-learn.org/stable/developers/advanced_installation.html#installing-build-dependencies
 RUN apt-get update && \
-    apt-get -y install build-essential libatlas-dev git wget curl nginx jq && \
-    if [ $py_version -eq 2 ]; \
-       then apt-get -y install python-dev python-setuptools \
-                     python-numpy python-scipy libatlas3-base; \
-       else apt-get -y install python3-dev python3-setuptools \
-                     python3-numpy python3-scipy libatlas3-base; fi
+    apt-get -y install build-essential libatlas-dev git wget curl nginx jq libatlas3-base
 
-# Install pip
-RUN cd /tmp && \
-     curl -O https://bootstrap.pypa.io/get-pip.py && \
-     if [ $py_version -eq 2 ]; \
-        then python2 get-pip.py; \
-        else python3 get-pip.py; fi && \
-     rm get-pip.py
+RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH=/miniconda3/bin:${PATH}
+
+RUN conda update -y conda && \
+    conda install -c conda-forge pyarrow=0.14.1 && \
+    conda install -c mlio -c conda-forge mlio-py && \
+    conda install -c anaconda scipy
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-# Install dependencies from pip
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+
 RUN pip install --no-cache -I scikit-learn==0.20.0 retrying

--- a/docker/0.20.0/final/Dockerfile.cpu
+++ b/docker/0.20.0/final/Dockerfile.cpu
@@ -1,5 +1,5 @@
 ARG py_version
-FROM sklearn-base:0.20.0-cpu-py$py_version
+FROM sklearn-base:0.20.0-cpu-py3
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 


### PR DESCRIPTION
*Description of changes:*
- Install miniconda3
- Update base and final Dockerfile.cpu files to integrate ML-IO library (high performance data access library for machine learning frameworks with support for multiple data formats)
- Update buildspec.yml
- Remove python version as an input argument
- Add apache arrow

*Testing:*
Built image successfully using CodeBuild and uploaded to ECR. Ran:
- unit tests
- integration tests using the new image in ECR
- manual notebook test that uses mlio for reading parquet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.