### PR TITLE
Fix csv unit test

### DIFF
--- a/test/unit/test_serving.py
+++ b/test/unit/test_serving.py
@@ -106,7 +106,7 @@ def test_output_fn_csv(np_array):
     response = serving.default_output_fn(np_array, content_types.CSV)
 
     assert response.get_data(as_text=True) == '1.0,1.0\n1.0,1.0\n'
-    assert response.content_type == content_types.CSV
+    assert content_types.CSV in response.content_type
 
 
 def test_output_fn_npz(np_array):


### PR DESCRIPTION
Content type in response also returns encoding, which was making this test fail earlier.

*Description of changes:*
- Fix csv unit test. Content type in response also returns encoding, which was making this test fail earlier. 
- This behavior is also observed in xgboost container: https://github.com/aws/sagemaker-xgboost-container/blob/master/test/unit/test_serving.py#L77

*Testing*
Tested by running unit tests. All tests passed.
```
test/unit/test_serving.py::test_input_fn_json[[42, 6, 9]-expected0] PASSED                                                                                                                           [  5%]
test/unit/test_serving.py::test_input_fn_json[[42.0, 6.0, 9.0]-expected1] PASSED                                                                                                                     [ 11%]
test/unit/test_serving.py::test_input_fn_json[["42", "6", "9"]-expected2] PASSED                                                                                                                     [ 17%]
test/unit/test_serving.py::test_input_fn_json[["42", "6", "9"]-expected3] PASSED                                                                                                                     [ 23%]
test/unit/test_serving.py::test_input_fn_csv[42\n6\n9\n-expected0] PASSED                                                                                                                            [ 29%]
test/unit/test_serving.py::test_input_fn_csv[42.0\n6.0\n9.0\n-expected1] PASSED                                                                                                                      [ 35%]
test/unit/test_serving.py::test_input_fn_csv[42\n6\n9\n-expected2] PASSED                                                                                                                            [ 41%]
test/unit/test_serving.py::test_input_fn_npz[np_array0] PASSED                                                                                                                                       [ 47%]
test/unit/test_serving.py::test_input_fn_npz[np_array1] PASSED                                                                                                                                       [ 52%]
test/unit/test_serving.py::test_input_fn_bad_content_type PASSED                                                                                                                                     [ 58%]
test/unit/test_serving.py::test_default_model_fn PASSED                                                                                                                                              [ 64%]
test/unit/test_serving.py::test_predict_fn PASSED                                                                                                                                                    [ 70%]
test/unit/test_serving.py::test_output_fn_json PASSED                                                                                                                                                [ 76%]
test/unit/test_serving.py::test_output_fn_csv PASSED                                                                                                                                                 [ 82%]
test/unit/test_serving.py::test_output_fn_npz PASSED                                                                                                                                                 [ 88%]
test/unit/test_serving.py::test_input_fn_bad_accept PASSED                                                                                                                                           [ 94%]
test/unit/test_training.py::test_single_machine PASSED                                                                                                                                               [100%]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
