### PR TITLE
Require ML-IO 0.1.x

### DIFF
--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -13,7 +13,7 @@ ENV PATH=/miniconda3/bin:${PATH}
 
 RUN conda update -y conda && \
     conda install -c conda-forge pyarrow=0.14.1 && \
-    conda install -c mlio -c conda-forge mlio-py && \
+    conda install -c mlio -c conda-forge mlio-py=0.1 && \
     conda install -c anaconda scipy
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.5.5', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.5.10', 'scikit-learn>=0.20.0', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']


### PR DESCRIPTION
*Description of changes:*
Set mlio dependency to require v0.1.x instead of installing the latest. mlio v0.2.x will be released later and introduce backwards incompatible changes, which we do not want to automatically include.

Also raised the sagemaker-containers requirement to >=2.5.10 to pick up an important bug fix for text/csv accept type during inference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
