### PR TITLE
change: use sagemaker-containers' ProcessRunner for executing entry p…

### DIFF
--- a/src/sagemaker_sklearn_container/training.py
+++ b/src/sagemaker_sklearn_container/training.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -28,8 +28,10 @@ def train(training_environment):
                                training arguments and hyperparameters
     """
     logger.info('Invoking user training script.')
-    framework.modules.run_module(training_environment.module_dir, training_environment.to_cmd_args(),
-                                 training_environment.to_env_vars(), training_environment.module_name)
+    framework.modules.download_and_install(training_environment.module_dir)
+    framework.entry_point.run(training_environment.module_dir, training_environment.user_entry_point,
+                              training_environment.to_cmd_args(), training_environment.to_env_vars(),
+                              runner=framework.runner.ProcessRunnerType)
 
 
 def main():

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -14,16 +14,21 @@ from __future__ import absolute_import
 
 from mock import MagicMock, patch
 
+import sagemaker_containers.beta.framework as framework
 from sagemaker_sklearn_container import training
 
 
-def mock_training_env(current_host='algo-1', module_dir='s3://my/script', module_name='svm', **kwargs):
-    return MagicMock(current_host=current_host, module_dir=module_dir, module_name=module_name, **kwargs)
+def mock_training_env(current_host='algo-1', module_dir='s3://my/script', user_entry_point='svm', **kwargs):
+    return MagicMock(current_host=current_host, module_dir=module_dir, user_entry_point=user_entry_point, **kwargs)
 
 
-@patch('sagemaker_containers.beta.framework.modules.run_module')
-def test_single_machine(run_module):
+@patch('sagemaker_containers.beta.framework.modules.download_and_install')
+@patch('sagemaker_containers.beta.framework.entry_point.run')
+def test_single_machine(run_entry_point, download_and_install):
     env = mock_training_env()
     training.train(env)
 
-    run_module.assert_called_with('s3://my/script', env.to_cmd_args(), env.to_env_vars(), 'svm')
+    download_and_install.assert_called_with(env.module_dir)
+
+    run_entry_point.assert_called_with(env.module_dir, env.user_entry_point, env.to_cmd_args(), env.to_env_vars(),
+                                       runner=framework.runner.ProcessRunnerType)


### PR DESCRIPTION
*Issue #, if available:*
aws/sagemaker-python-sdk#941

*Description of changes:*
* this change is specifically to take advantage of https://github.com/aws/sagemaker-containers/blob/master/src/sagemaker_containers/_process.py#L76-L86
* same as aws/sagemaker-pytorch-container#135 and aws/sagemaker-mxnet-container#114
* the approach is copied from https://github.com/aws/sagemaker-chainer-container/blob/master/src/sagemaker_chainer_container/training.py (but without the MPI stuff)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
