### PR TITLE
Update sagemaker-containers to >=2.6.4 to fix network isolation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.5.10', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.6.4', 'scikit-learn>=0.20.0', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']


### PR DESCRIPTION
*Description of changes:*
Commit [f5dac94](https://github.com/aws/sagemaker-scikit-learn-container/commit/f5dac9447f9ac0da8844b3fe66d5bc7291d1cf0a) introduced a breaking change for network isolation. A fix was released by sagemaker-containers in v2.6.4. This PR updates the minimum version for sagemaker-containers to 2.6.4.

*Testing:*
Custom image built with this change and a simple mnist training job run with network isolation enabled. Job passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
