### PR TITLE
Bump sagemaker-containers version to 2.8.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.6.4', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.8.3', 'scikit-learn>=0.20.0', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']


### PR DESCRIPTION
*Description of changes:*

*Testing*
`pytest test/unit`

```
test/unit/test_serving.py::test_input_fn_json[[42, 6, 9]-expected0] PASSED                                                                                                                           [  5%]
test/unit/test_serving.py::test_input_fn_json[[42.0, 6.0, 9.0]-expected1] PASSED                                                                                                                     [ 11%]
test/unit/test_serving.py::test_input_fn_json[["42", "6", "9"]-expected2] PASSED                                                                                                                     [ 16%]
test/unit/test_serving.py::test_input_fn_json[["42", "6", "9"]-expected3] PASSED                                                                                                                     [ 22%]
test/unit/test_serving.py::test_input_fn_csv[42\n6\n9\n-expected0] PASSED                                                                                                                            [ 27%]
test/unit/test_serving.py::test_input_fn_csv[42.0\n6.0\n9.0\n-expected1] PASSED                                                                                                                      [ 33%]
test/unit/test_serving.py::test_input_fn_csv[42\n6\n9\n-expected2] PASSED                                                                                                                            [ 38%]
test/unit/test_serving.py::test_input_fn_npz[np_array0] PASSED                                                                                                                                       [ 44%]
test/unit/test_serving.py::test_input_fn_npz[np_array1] PASSED                                                                                                                                       [ 50%]
test/unit/test_serving.py::test_input_fn_bad_content_type PASSED                                                                                                                                     [ 55%]
test/unit/test_serving.py::test_default_model_fn PASSED                                                                                                                                              [ 61%]
test/unit/test_serving.py::test_predict_fn PASSED                                                                                                                                                    [ 66%]
test/unit/test_serving.py::test_output_fn_json PASSED                                                                                                                                                [ 72%]
test/unit/test_serving.py::test_output_fn_csv PASSED                                                                                                                                                 [ 77%]
test/unit/test_serving.py::test_output_fn_npz PASSED                                                                                                                                                 [ 83%]
test/unit/test_serving.py::test_input_fn_bad_accept PASSED                                                                                                                                           [ 88%]
test/unit/test_serving.py::test_import_module_execution_parameters PASSED                                                                                                                            [ 94%]
test/unit/test_training.py::test_single_machine PASSED                                                                                                                                               [100%]
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
