### PR TITLE
Fix Pandas version for backward compatibility

### DIFF
--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -21,4 +21,4 @@ RUN conda update -y conda && \
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # Install Scikit-Learn; 0.20.0 supports both python 2.7+ and 3.4+
-RUN pip install --no-cache -I scikit-learn==0.20.0 retrying
+RUN python -m pip install --no-cache -I scikit-learn==0.20.0

--- a/docker/0.20.0/final/Dockerfile.cpu
+++ b/docker/0.20.0/final/Dockerfile.cpu
@@ -1,7 +1,11 @@
-ARG py_version
 FROM sklearn-base:0.20.0-cpu-py3
+ARG py_version
 
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+COPY requirements.txt /requirements.txt
+RUN python -m pip install -r /requirements.txt && \
+    rm /requirements.txt
 
 COPY dist/sagemaker_sklearn_container-1.0-py2.py3-none-any.whl /sagemaker_sklearn_container-1.0-py2.py3-none-any.whl
 RUN pip install --no-cache /sagemaker_sklearn_container-1.0-py2.py3-none-any.whl && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pandas==0.25.*  # Fix Pandas version to 0.25 for 0.20.0-cpu-py3 release.
+retrying==1.3.3
+sagemaker-containers>=2.8.3
+scikit-learn>=0.20.0
+six

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.8.3', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=read("requirements.txt"),
+
     extras_require={
-        'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
-                 'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']
+        "test": read("test-requirements.txt")
     },
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,13 @@
+Flask
+PyYAML
+boto3>=1.4.8
+coverage
+docker-compose
+flake8
+mock
+pytest
+pytest-cov
+pytest-xdist
+requests==2.18.4
+sagemaker>=1.3.0
+tox

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -1,0 +1,4 @@
+def test_pandas_version():
+    import pandas as pd
+    major, minor, patch = pd.__version__.split('.')
+    assert major == '0'


### PR DESCRIPTION
*Description of changes:*

Pandas version was 0.25 up to this aa517d6043c9c47d876814d78e0be18c4b4110ae, but the tip of the master branch will build a container with Pandas 1.0. This breaks backward compatibility since Pandas removed `df.ix` in 1.0. This PR installs Pandas 0.25 in the container.

Currently in prod:
```
$ docker run --rm -it 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:30adb1aa9af5 bash
root@1563d1a93d80:/# python
Python 3.7.4 (default, Aug 13 2019, 20:35:49) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
>>> pd.__version__
'0.25.2'
>>> df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
>>> df.ix[0]
__main__:1: FutureWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated
a    1
b    3
Name: 0, dtype: int64
```

Tip of the master branch:
```
$ docker run --rm -it 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3 bash
root@81730291ae0e:/# python
Python 3.7.6 (default, Jan  8 2020, 19:59:22) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
>>> pd.__version__
'1.0.3'
>>> df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
>>> 
>>> df.ix[0]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/miniconda3/lib/python3.7/site-packages/pandas/core/generic.py", line 5274, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'ix'
```

Built from this PR:
```
$ docker build -t sklearn-base:0.20.0-cpu-py3  -f docker/0.20.0/base/Dockerfile.cpu .
$ python3 -m pip install wheel setuptools
$ python3 setup.py bdist_wheel
$ docker build -t preprod-sklearn:0.20.0-cpu-py3 -f docker/0.20.0/final/Dockerfile.cpu .
$ docker run --rm -it preprod-sklearn:0.20.0-cpu-py3 bash
root@6148bf3938b3:/# python
Python 3.7.6 (default, Jan  8 2020, 19:59:22) 
[GCC 7.3.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
>>> pd.__version__
'0.25.3'
>>> df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
>>> df.ix[0]
__main__:1: FutureWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated
a    1
b    3
Name: 0, dtype: int64
```

Testing: `pytest test/unit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
