### PR TITLE
change: Use sagemaker-training for training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ numpy
 pandas==0.25.*  # Fix Pandas version to 0.25 for 0.20.0-cpu-py3 release.
 retrying==1.3.3
 sagemaker-containers>=2.8.3
+sagemaker-training>=3.4.2
 scikit-learn>=0.20.0
 six

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
 
-    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.8.3', 'scikit-learn>=0.20.0', 'six'],
+    install_requires=['numpy', 'pandas', 'retrying==1.3.3', 'sagemaker-containers >= 2.8.3', 'sagemaker-training >= 3.4.2', 'scikit-learn>=0.20.0', 'six'],
     extras_require={
         'test': ['tox', 'flake8', 'coverage', 'pytest', 'pytest-cov', 'pytest-xdist', 'mock', 'Flask', 'boto3>=1.4.8',
                  'docker-compose', 'sagemaker>=1.3.0', 'PyYAML', 'requests==2.18.4']

--- a/src/sagemaker_sklearn_container/training.py
+++ b/src/sagemaker_sklearn_container/training.py
@@ -13,7 +13,7 @@
 from __future__ import absolute_import
 import logging
 
-import sagemaker_containers.beta.framework as framework
+from sagemaker_training import entry_point, environment, runner
 
 logger = logging.getLogger(__name__)
 
@@ -28,11 +28,12 @@ def train(training_environment):
                                training arguments and hyperparameters
     """
     logger.info('Invoking user training script.')
-    framework.modules.download_and_install(training_environment.module_dir)
-    framework.entry_point.run(training_environment.module_dir, training_environment.user_entry_point,
-                              training_environment.to_cmd_args(), training_environment.to_env_vars(),
-                              runner=framework.runner.ProcessRunnerType)
+    entry_point.run(uri=training_environment.module_dir,
+                    user_entry_point=training_environment.user_entry_point,
+                    args=training_environment.to_cmd_args(),
+                    env_vars=training_environment.to_env_vars(),
+                    runner_type=runner.ProcessRunnerType)
 
 
 def main():
-    train(framework.training_env())
+    train(environment.Environment())

--- a/test/unit/test_training.py
+++ b/test/unit/test_training.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 from mock import MagicMock, patch
 
-import sagemaker_containers.beta.framework as framework
+from sagemaker_training import runner
 from sagemaker_sklearn_container import training
 
 
@@ -22,13 +22,13 @@ def mock_training_env(current_host='algo-1', module_dir='s3://my/script', user_e
     return MagicMock(current_host=current_host, module_dir=module_dir, user_entry_point=user_entry_point, **kwargs)
 
 
-@patch('sagemaker_containers.beta.framework.modules.download_and_install')
-@patch('sagemaker_containers.beta.framework.entry_point.run')
-def test_single_machine(run_entry_point, download_and_install):
+@patch('sagemaker_training.entry_point.run')
+def test_single_machine(run_entry_point):
     env = mock_training_env()
     training.train(env)
 
-    download_and_install.assert_called_with(env.module_dir)
-
-    run_entry_point.assert_called_with(env.module_dir, env.user_entry_point, env.to_cmd_args(), env.to_env_vars(),
-                                       runner=framework.runner.ProcessRunnerType)
+    run_entry_point.assert_called_with(uri=env.module_dir,
+                                       user_entry_point=env.user_entry_point,
+                                       args=env.to_cmd_args(),
+                                       env_vars=env.to_env_vars(),
+                                       runner_type=runner.ProcessRunnerType)


### PR DESCRIPTION
*Description of changes:*
This PR replaces the deprecated [sagemaker-containers](https://github.com/aws/sagemaker-containers) package with the new [sagemaker-training](https://github.com/aws/sagemaker-training-toolkit) package for training functionality.

*Testing done:*
Ran unit tests locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
