### PR TITLE
fix: bump version of sagemaker-training for script entry point fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 pandas>=1.0.3,<2
 retrying==1.3.3
 sagemaker-containers>=2.8.3
-sagemaker-training>=3.4.2
+sagemaker-training>=3.5.2
 scikit-learn==0.23.1
 six


### PR DESCRIPTION
*Description of changes:*
Consuming the fix from https://github.com/aws/sagemaker-training-toolkit/pull/64

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
