### PR TITLE
Bump ML-IO version to 0.5

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -21,8 +21,8 @@ RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.s
 ENV PATH=/miniconda3/bin:${PATH}
 
 RUN conda update -y conda && \
-    conda install -c conda-forge pyarrow=0.14.1 && \
-    conda install -c mlio -c conda-forge mlio-py=0.1 && \
+    conda install -c conda-forge pyarrow=0.16.0 && \
+    conda install -c mlio -c conda-forge mlio-py=0.5 && \
     conda install -c anaconda scipy
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 conda_deps=
-    pyarrow=0.14.1
-    mlio-py=0.1
+    pyarrow=0.16.0
+    mlio-py=0.5
 conda_channels=
     conda-forge
     mlio


### PR DESCRIPTION
*Description of changes:*
Bump ML-IO to v0.5 and PyArrow to v0.16.0, per ML-IO [documentation](https://github.com/awslabs/ml-io/blob/master/doc/build.md#Building-the-Apache-Arrow-Integration).

Unit tests run with tox, all tests passing. Integration tests run separately, all tests passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
