### PR TITLE
fix: dependency conflict with libprotobuf in base Dockerfile

### DIFF
--- a/docker/0.21.2/base/Dockerfile.cpu
+++ b/docker/0.21.2/base/Dockerfile.cpu
@@ -12,7 +12,7 @@ RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.s
 ENV PATH=/miniconda3/bin:${PATH}
 
 RUN conda update -y conda && \
-    conda install -c conda-forge pyarrow=0.15.1 && \
+    conda install -c conda-forge libprotobuf=3.10.1 pyarrow=0.15.1 && \
     conda install -c mlio -c conda-forge mlio-py=0.2 && \
     conda install -c anaconda scipy
 


### PR DESCRIPTION
*Description of changes:*
* Pins version of libprotobuf, newer versions of libprotobuf cause dependency conflicts when building with pyarrow/mlio
  * pinned version comes from existing sklearn 0.21-1 image


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
