### PR TITLE
upgrade extension package to 1.1.1

### DIFF
--- a/docker/0.21.2/extension/Dockerfile.cpu
+++ b/docker/0.21.2/extension/Dockerfile.cpu
@@ -6,4 +6,4 @@ RUN pip freeze | grep -q 'scikit-learn==0.21.2'; \
 		else echo 'ERROR: Expected scikit-learn version is 0.21.2, check base images for scikit-learn version' && \
 			 exit 1; fi
 
-RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==1.1.0
+RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==1.1.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Upgrades the version of the extension package to 1.1.1 in the docker file.
See most recent version is version 1.1.1 in [pypi ](https://pypi.org/project/sagemaker-scikit-learn-extension/).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
