### PR TITLE
fix python version of miniconda to py37

### DIFF
--- a/docker/0.21.2/base/Dockerfile.cpu
+++ b/docker/0.21.2/base/Dockerfile.cpu
@@ -5,9 +5,9 @@ FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get -y install build-essential libatlas-dev git wget curl nginx jq libatlas3-base
 
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh && \
+    bash Miniconda3-py37_4.8.3-Linux-x86_64.sh -bfp /miniconda3 && \
+    rm Miniconda3-py37_4.8.3-Linux-x86_64.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 


### PR DESCRIPTION
*Description of changes:*
* Error when building image with latest version of miniconda, mlio version 0.2 requires python version 3.6 or 3.7
  * `mlio-py=0.2 -> python[version='>=3.6,<3.7.0a0|>=3.7,<3.8.0a0']`
* http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh uses 3.8
* Tested by building locally
* Note that this is on the 0.21-1 branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
