### PR TITLE
Upgrade sklearn version to 0.23.2

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -32,4 +32,4 @@ ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 PYTHONIOENCODING=UTF-8 LANG=C.U
 # Install Scikit-Learn
 # Scikit-learn 0.20 was the last version to support Python 2.7 and Python 3.4.
 # Scikit-learn now requires Python 3.6 or newer.
-RUN python -m pip install --no-cache -I scikit-learn==0.23.1
+RUN python -m pip install --no-cache -I scikit-learn==0.23.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pandas>=1.0.3,<2
 retrying==1.3.3
 sagemaker-containers>=2.8.3
 sagemaker-training>=3.5.2
-scikit-learn==0.23.1
+scikit-learn==0.23.2
 six

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ max-line-length = 120
 
 [testenv]
 deps =
-    sklearn0.23: scikit-learn==0.23.1
+    sklearn0.23: scikit-learn==0.23.2
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 conda_deps=


### PR DESCRIPTION
*Description of changes:*
* Upgrade version of sklearn to 0.23.2
  * See [What's new in 0.23.2](https://scikit-learn.org/stable/whats_new/v0.23.html)
* Tested with `tox` and integration tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
