### PR TITLE
Fix python version to 3.7

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -2,6 +2,8 @@ ARG UBUNTU_VERSION=16.04
 
 FROM ubuntu:${UBUNTU_VERSION}
 
+ARG CONDA_VERSION=4.8.3
+ARG CONDA_PY_VERSION=37
 ARG PYTHON_VERSION=3.7
 ARG PYARROW_VERSION=0.16.0
 ARG MLIO_VERSION=0.5.1
@@ -20,9 +22,10 @@ RUN apt-get update && \
         libatlas3-base \
         openjdk-8-jdk-headless
 
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${CONDA_VERSION}-Linux-x86_64.sh && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 

--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -1,4 +1,10 @@
-FROM ubuntu:16.04
+ARG UBUNTU_VERSION=16.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG PYTHON_VERSION=3.7
+ARG PYARROW_VERSION=0.16.0
+ARG MLIO_VERSION=0.5.1
 
 # Install python and other scikit-learn runtime dependencies
 # Dependency list from http://scikit-learn.org/stable/developers/advanced_installation.html#installing-build-dependencies
@@ -20,9 +26,10 @@ RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.s
 
 ENV PATH=/miniconda3/bin:${PATH}
 
-RUN conda update -y conda && \
-    conda install -c conda-forge pyarrow=0.16.0 && \
-    conda install -c mlio -c conda-forge mlio-py=0.5 && \
+RUN conda install python=${PYTHON_VERSION} && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION} && \
     conda install -c anaconda scipy
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules


### PR DESCRIPTION
*Description of changes:*

Fixes Python version in Conda. Without fixing the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

Using the current production image:
```
docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3-1.0.173.0 sh -c 'python3 -m pip install tensorflow==2.1.0'
ERROR: Could not find a version that satisfies the requirement tensorflow==2.1.0 (from versions: 2.2.0rc1, 2.2.0rc2, 2.2.0rc3, 2.2.0rc4, 2.2.0, 2.2.1, 2.3.0rc0, 2.3.0rc1, 2.3.0rc2, 2.3.0, 2.3.1)
ERROR: No matching distribution found for tensorflow==2.1.0
```
```
docker run --rm -it 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3-1.0.173.0 bash
root@9465565f2e84:/# python3
Python 3.8.5 | packaged by conda-forge | (default, Jul 31 2020, 02:39:48) 
```
On SageMaker,
```
sklearn_estimator = SKLearn(
    entry_point='script.py',
    framework_version="0.23-1",
    source_dir=os.getcwd(),
    ...
```
where
```
$ cat requirements.txt
tensorflow==2.1.0
```
the output is
```
ERROR: Could not find a version that satisfies the requirement tensorflow==2.1.0 (from -r requirements.txt (line 2)) (from versions: 2.2.0rc1, 2.2.0rc2, 2.2.0rc3, 2.2.0rc4, 2.2.0, 2.2.1, 2.3.0rc0, 2.3.0rc1, 2.3.0rc2, 2.3.0, 2.3.1)
```

Using the image built with the changes in this PR:
```
docker run --rm -it preprod-sklearn:0.23-1-cpu-py3 bash
root@d2ce8a4be623:/# python3
Python 3.7.8 | packaged by conda-forge | (default, Jul 23 2020, 03:54:19) 
```
```
docker run preprod-sklearn:0.23-1-cpu-py3 sh -c 'python3 -m pip install tensorflow==2.1.0'
...
Successfully installed absl-py-0.10.0 aiohttp-3.6.2 astor-0.8.1 async-timeout-3.0.1 attrs-20.2.0 cachetools-4.1.1 gast-0.2.2 google-auth-1.22.0 google-auth-oauthlib-0.4.1 │1-cpu-py3-1.0.173.0 sh -c 'python3 -m pip install tensorflow==2.1.0'
google-pasta-0.2.0 grpcio-1.32.0 h5py-2.10.0 importlib-metadata-2.0.0 keras-applications-1.0.8 keras-preprocessing-1.1.2 markdown-3.2.2 multidict-4.7.6 oauthlib-3.1.0 opt-│ERROR: Could not find a version that satisfies the requirement tensorflow==2.1.0 (from versions: 2.2.0rc1, 2.2.0rc2, 2.2.0rc3, 2.2.0rc4, 2.2.0, 2.2.1,
einsum-3.3.0 pyasn1-0.4.8 pyasn1-modules-0.2.8 requests-oauthlib-1.3.0 rsa-4.6 tensorboard-2.1.1 tensorflow-2.1.0 tensorflow-estimator-2.1.0 termcolor-1.1.0 typing-extensi│ 2.3.0rc0, 2.3.0rc1, 2.3.0rc2, 2.3.0, 2.3.1)
ons-3.7.4.3 wrapt-1.12.1 yarl-1.6.0 zipp-3.2.0
```
On SageMaker,
```
sklearn_estimator = SKLearn(
    entry_point='script.py',
    image_name="<dev account>.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.23-1-cpu-py3",
    source_dir=os.getcwd(),
    ...
```
```
Collecting tensorflow==2.1.0
  Downloading tensorflow-2.1.0-cp37-cp37m-manylinux2010_x86_64.whl (421.8 MB)
```

The python version is fixed by downloading a specific Conda installation file as well as fixing the Python version in the Conda environment.

*Testing*

tox

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
