### PR TITLE
Pin python version to 3.7 in 0.20.0 image

### DIFF
--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -3,6 +3,7 @@ ARG UBUNTU_VERSION=16.04
 FROM ubuntu:${UBUNTU_VERSION}
 
 ARG CONDA_VERSION=4.7.12.1
+ARG CONDA_CHECKSUM="81c773ff87af5cfac79ab862942ab6b3"
 ARG PYTHON_VERSION=3.7
 ARG PYARROW_VERSION=0.14.1
 ARG MLIO_VERSION=0.1
@@ -14,6 +15,7 @@ RUN apt-get update && \
 
 RUN cd /tmp && \
     curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | md5sum -c - && \
     bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
     rm /tmp/Miniconda3.sh
 

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -1,19 +1,28 @@
-FROM ubuntu:16.04
+ARG UBUNTU_VERSION=16.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG CONDA_VERSION=4.7.12.1
+ARG PYTHON_VERSION=3.7
+ARG PYARROW_VERSION=0.14.1
+ARG MLIO_VERSION=0.1
 
 # Install python and other scikit-learn runtime dependencies
 # Dependency list from http://scikit-learn.org/stable/developers/advanced_installation.html#installing-build-dependencies
 RUN apt-get update && \
     apt-get -y install build-essential libatlas-dev git wget curl nginx jq libatlas3-base
 
-RUN curl -LO http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash Miniconda3-latest-Linux-x86_64.sh -bfp /miniconda3 && \
-    rm Miniconda3-latest-Linux-x86_64.sh
+RUN cd /tmp && \
+    curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh && \
+    bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
+    rm /tmp/Miniconda3.sh
 
 ENV PATH=/miniconda3/bin:${PATH}
 
-RUN conda update -y conda && \
-    conda install -c conda-forge pyarrow=0.14.1 && \
-    conda install -c mlio -c conda-forge mlio-py=0.1 && \
+RUN conda install python=${PYTHON_VERSION} && \
+    conda update -y conda && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION} && \
     conda install -c anaconda scipy
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules


### PR DESCRIPTION
*Description of changes:*

Fixes Python version in Conda. Without fixing the Python version, a rebuild of the image will bump the Python version when conda-latest bumps the Python version.

See https://github.com/aws/sagemaker-scikit-learn-container/pull/58.

The current prod image `0.20.0-cpu-py3` uses miniconda 4.7.12 and python 3.7:
```
$ docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3 sh -c 'conda --version'
conda 4.7.12
```
```
$ docker run 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3 sh -c 'python3 --version'
Python 3.7.4
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
