### PR TITLE
Install kitware-archive-keyring to rotate kitware signing keys

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -45,6 +45,7 @@ RUN apt-get update && \
         cmake=3.18.4-0kitware1 \
         cmake-data=3.18.4-0kitware1 \
         doxygen \
+        kitware-archive-keyring \
         libcurl4-openssl-dev \
         libssl-dev \
         libtool \
@@ -54,6 +55,7 @@ RUN apt-get update && \
         python3-pip \
         zlib1g-dev \
         && \
+    rm /etc/apt/trusted.gpg.d/kitware.gpg && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \


### PR DESCRIPTION
*Issue #, if available:*

#65 

*Description of changes:*

Fixes #65. See step 5 of https://apt.kitware.com/.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
