### PR TITLE
Update the extension package version to 2.2.1

### DIFF
--- a/docker/0.23-1/extension/Dockerfile.cpu
+++ b/docker/0.23-1/extension/Dockerfile.cpu
@@ -6,4 +6,4 @@ RUN pip freeze | grep -q 'scikit-learn==0.23.2'; \
 		else echo 'ERROR: Expected scikit-learn version is 0.23.2, check base images for scikit-learn version' && \
 			 exit 1; fi
 
-RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==2.1.0
+RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==2.2.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
sagemaker-scikit-learn-extension v2.2.1 released: https://pypi.org/project/sagemaker-scikit-learn-extension/
Upgrading docker to this version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
