### PR TITLE
Upgrade version of sagemaker-scikit-learn-extension package to 2.3.0

### DIFF
--- a/ci/buildspec-extension.yml
+++ b/ci/buildspec-extension.yml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     SKLEARN_FRAMEWORK_VERSION: "0.23-1"
-    EXTENSION_FRAMEWORK_VERSION: "2.2.1-1"
+    EXTENSION_FRAMEWORK_VERSION: "2.3-1"
 
 phases:
   install:

--- a/docker/0.23-1/extension/Dockerfile.cpu
+++ b/docker/0.23-1/extension/Dockerfile.cpu
@@ -6,4 +6,4 @@ RUN pip freeze | grep -q 'scikit-learn==0.23.2'; \
 		else echo 'ERROR: Expected scikit-learn version is 0.23.2, check base images for scikit-learn version' && \
 			 exit 1; fi
 
-RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==2.2.1
+RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==2.3.0

--- a/docker/0.23-1/extension/README.md
+++ b/docker/0.23-1/extension/README.md
@@ -49,8 +49,8 @@ The "extension" Dockerfiles use final images for building.
 
 Build the third additional Dockerfile needed for SageMaker Scikit-learn Extension Container. This Dockerfile specifies a hard dependency on a certain version of scikit-learn (i.e. v0.23.2).
 
-Tagging scheme is based on extension-<Scikit-learn-Extension_version>-<SageMaker_version>-cpu-py<python_version>. (e.g. extension-2.2.1-1-cpu-py3). Make sure the "extension" image is tagged in accordance with the  `extension` (i.e. `extension-2.2.1-1-cpu-py3`).
+Tagging scheme is based on extension-<Scikit-learn-Extension_version>-<SageMaker_version>-cpu-py<python_version>. (e.g. extension-2.3-1-cpu-py3). Make sure the "extension" image is tagged in accordance with the  `extension` (i.e. `extension-2.3-1-cpu-py3`).
 
 ```
-docker build -t preprod-sklearn-extension:2.2.1-1-cpu-py3 -f  docker/0.23-1/extension/Dockerfile.cpu .
+docker build -t preprod-sklearn-extension:2.3-1-cpu-py3 -f  docker/0.23-1/extension/Dockerfile.cpu .
 ```


### PR DESCRIPTION


*Description of changes:*
Upgrading version of the sagemaker-scikit-learn-extension package to 2.3.0. This upgrade includes a time series data transformer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
