### PR TITLE
Add ubuntu security updates

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -13,6 +13,7 @@ ARG MLIO_VERSION=0.6.0
 # Install python and other scikit-learn runtime dependencies
 # Dependency list from http://scikit-learn.org/stable/developers/advanced_installation.html#installing-build-dependencies
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get -y install --no-install-recommends \
         build-essential \
         curl \


### PR DESCRIPTION
*Issue #, if available:*

https://ubuntu.com/security/CVE-2021-33910

*Description of changes:*

Similar to https://github.com/aws/sagemaker-xgboost-container/pull/194 we want to include all ubuntu security updates on each container build automatically so we add this in the Dockerfile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
