### PR TITLE
Add time series dependencies to extension Docker

### DIFF
--- a/docker/0.23-1/extension/Dockerfile.cpu
+++ b/docker/0.23-1/extension/Dockerfile.cpu
@@ -7,3 +7,7 @@ RUN pip freeze | grep -q 'scikit-learn==0.23.2'; \
 			 exit 1; fi
 
 RUN pip install --upgrade --no-cache --no-deps sagemaker-scikit-learn-extension==2.4.0
+RUN python -m pip install statsmodels==0.9.0
+RUN python -m pip install matrixprofile==1.1.10
+RUN python -m pip install stumpy==1.7.2
+RUN python -m pip install --no-deps tsfresh==0.17.0


### PR DESCRIPTION
*Description of changes:*
Adding required dependencies to run TSFeatureExtractor from sagemaker-scikit-learn-extension.


The docker image could be built locally and a fit_transform job with the TSFeatureExtractor ran correctly and gave the expected output.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
