### PR TITLE
0.20.0 numpy pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==3.4.6
-numpy
+numpy==1.19.5
 pandas==0.25.*  # Fix Pandas version to 0.25 for 0.20.0-cpu-py3 release.
 retrying==1.3.3
 sagemaker-containers>=2.8.3


### PR DESCRIPTION
While using the 0.20.0 image, the code worked as expected back in January. Currently it's failing because from requiremenet.txt we are pulling the latest verion of numpy. This is causing a code to break even though there were no changes made to them.  The version 1.19.* works without an issue for a customer. 

The solution for this problem is to pin the numpy version to 1.19.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
