### PR TITLE
Adding docker login to build script

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -13,6 +13,7 @@ phases:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
+    - docker login -u $dockerhub_username -p $dockerhub_password
     - docker build -t sklearn-base:0.20.0-cpu-py3  -f docker/0.20.0/base/Dockerfile.cpu .
     - pip install wheel setuptools
     - python setup.py bdist_wheel


### PR DESCRIPTION
Codebuild is failing with an error 

```You have reached your pull rate limit. You may increase the limit by authenticating and upgrading```

This issue stems from limited number of pull requests. Anonymous pulls are based on the IP performing the pull, and if you are behind a proxy or NAT, that may mean others on the same network are included in your limit


Fix is to include the credentials with git pull request using `docker login` command. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
