### PR TITLE
Upgrade SM Training toolkit package from 3.6.2 to 4.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ sagemaker-inference==1.2.0
 retrying==1.3.3
 sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.2.0
-sagemaker-training==3.6.2
+sagemaker-training==4.0.1
 scikit-learn==0.23.2
 scipy==1.5.3
 six==1.15.0


### PR DESCRIPTION
*Issue #, if available:*
The latest sagemaker-training package addresses few issues like enabling custom failure log messages in training. 

*Description of changes:*
Upgrade sagemaker-training package to latest version ~ 4.0.1
https://pypi.org/project/sagemaker-training/4.0.1/#history

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
