### PR TITLE
fix apt-get update error

### DIFF
--- a/docker/0.23-1/base/Dockerfile.cpu
+++ b/docker/0.23-1/base/Dockerfile.cpu
@@ -36,9 +36,10 @@ RUN apt-get update && \
         && \
     wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
         gpg --dearmor - | \
-        tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+        tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
     apt-get update && \
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg && \
     apt-get install -y --no-install-recommends \
         autoconf \
         automake \
@@ -56,7 +57,6 @@ RUN apt-get update && \
         python3-pip \
         zlib1g-dev \
         && \
-    rm /etc/apt/trusted.gpg.d/kitware.gpg && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \


### PR DESCRIPTION
*Issue #87 #65*

*Description of changes:*
Update the path of gpg keys based on latest instructions from [kitware](https://apt.kitware.com/)
Switch the order of installing kitware-archive-keyring and removing keys to prevent the error that no keys found to verify the signed repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
