### PR TITLE
Add docker login to extension buildspec

### DIFF
--- a/ci/buildspec-extension.yml
+++ b/ci/buildspec-extension.yml
@@ -18,6 +18,7 @@ phases:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
+    - docker login -u $dockerhub_username -p $dockerhub_password
     - docker build -t sklearn-base:$SKLEARN_FRAMEWORK_VERSION-cpu-py3  -f docker/$SKLEARN_FRAMEWORK_VERSION/base/Dockerfile.cpu .
     - pip install wheel setuptools
     - python setup.py bdist_wheel


### PR DESCRIPTION
*Issue #, if available:*
Just like in commit: https://github.com/aws/sagemaker-scikit-learn-container/commit/13e99bae045e1d1b5beae5cbd9a672755ae7323a

We want to add docker login to extension build so that we don't get throttling exceptions.

*Description of changes:*
Add docker login command to ci/buildspec-extension.yml.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
