### PR TITLE
Hard code version itsdangerous==2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.16.4
 botocore==1.19.4
 cryptography==3.4.6
 Flask==1.1.1
+itsdangerous==2.0.1
 gunicorn==20.0.4
 model-archiver==1.0.3
 multi-model-server==1.1.1


### PR DESCRIPTION
-Fix error `'cannot import name 'json''`, related to release 2.1.0 (https://pypi.org/project/itsdangerous/2.1.0/)

*Issue #, if available:*

*Description of changes:*
Hard coded version `itsdangerous==2.0.1`, imported by Flask and broke after latest release 2.1.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
