### PR TITLE
Add CI improvement

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -27,4 +27,18 @@ phases:
     commands:
     - echo Build completed on `date`
     - echo Pushing the Docker image...
-    - docker push 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:$FRAMEWORK_VERSION-cpu-py3
+    - |
+      case $CODEBUILD_WEBHOOK_EVENT in
+        PULL_REQUEST_MERGED)
+          docker push 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:$FRAMEWORK_VERSION-cpu-py3 | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+          ;;
+        PULL_REQUEST_CREATED | PULL_REQUEST_UPDATED | PULL_REQUEST_REOPENED)
+          # pushes test tag for manual verification, requires cleanup in ECR every once in a while though
+          TEST_TAG=515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:$FRAMEWORK_VERSION-cpu-py3-test
+          docker tag preprod-sklearn:$FRAMEWORK_VERSION-cpu-py3 ${TEST_TAG}
+          docker push ${TEST_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
+          ;;
+        *)
+          echo Undefined behavior for webhook event type $CODEBUILD_WEBHOOK_EVENT
+          ;;
+      esac


### PR DESCRIPTION
- Add branching on github webhook
  - Will make test image on PR open and will
    not override existing image
- Will only override existing image on merge

*Issue #, if available:*

*Description of changes:*

Recently scikitlearn CI did not build on PR, only on push. This slows down our dev workflow. That is enabled now for PRs but we need to distinguish between merges and just opening the PR. With this change, PR will push to a test image tag for manual testing.

This matches the process/behavior in https://github.com/aws/sagemaker-xgboost-container (buildspec is out of band though)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
