### PR TITLE
remove stale package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,7 @@ psutil==5.7.2
 python-dateutil==2.8.1
 sagemaker-inference==1.2.0
 retrying==1.3.3
-sagemaker-containers==2.8.6.post2
-sagemaker-inference==1.2.0
-sagemaker-training==4.0.1
+sagemaker-training==4.1.2
 scikit-learn==1.0.2
 scipy==1.5.3
 six==1.15.0


### PR DESCRIPTION
*Issue #, if available:*
SKLearn containers are having old sagemaker-training package which is conflicting with latest one. Hence the users are not able to see the exact stack trace when failure occurs

*Description of changes:*
- Remove `sagemaker-containers` package from `requirements.txt` as it is deprecated.
- Remove duplicate entry of ` sagemaker-inference`
- Upgrade `sagemaker-training` pypi package version to `1.2`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
