### PR TITLE
Reverting numpy 1.21.2 to 1.19.2 and adding regression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ itsdangerous==2.0.1
 gunicorn==20.0.4
 model-archiver==1.0.3
 multi-model-server==1.1.1
-numpy==1.21.0
+numpy==1.19.2
 pandas==1.1.3
 protobuf==3.20.1
 psutil==5.7.2

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -1,4 +1,12 @@
+import pandas as pd
+
+
 def test_pandas_version():
     import pandas as pd
     major, minor, patch = pd.__version__.split('.')
     assert major == '1'
+
+
+def test_pyarrow_to_parquet_conversion_regression_issue_106():
+    df = pd.DataFrame({'x': [1, 2]})
+    df.to_parquet('test.parquet', engine='pyarrow')


### PR DESCRIPTION
Issue #, if available:
* fixing https://github.com/aws/sagemaker-scikit-learn-container/issues/106
* Added regression to catch the re occurrence and to verify change is fixed with this commit
Description of changes:
* Numpy 1.2x.x broke the integration with Pyarrow 1.0. hence Rolling back numpy version to 1.19.2
* Added regression test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.