### PR TITLE
Reverting numpy 1.21.2 to 1.19.2, updating boto3 to 1.24.17, fixing docker build and adding regression

### DIFF
--- a/docker/0.23-1/final/Dockerfile.cpu
+++ b/docker/0.23-1/final/Dockerfile.cpu
@@ -9,7 +9,8 @@ RUN python -m pip install -r /requirements.txt && \
 
 COPY dist/sagemaker_sklearn_container-2.0-py3-none-any.whl /sagemaker_sklearn_container-2.0-py3-none-any.whl
 # https://github.com/googleapis/google-cloud-python/issues/6647
-RUN rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.19.4.dist-info && \
+RUN conda install numpy --force-reinstall && \
+    rm -rf /miniconda3/lib/python3.7/site-packages/numpy-1.19.4.dist-info && \
     pip install --no-cache /sagemaker_sklearn_container-2.0-py3-none-any.whl && \
     rm /sagemaker_sklearn_container-2.0-py3-none-any.whl
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-boto3==1.16.4
-botocore==1.19.4
+boto3==1.24.17
+botocore==1.27.18
 cryptography==35.0.0
 Flask==1.1.1
 itsdangerous==2.0.1
 gunicorn==20.0.4
 model-archiver==1.0.3
 multi-model-server==1.1.1
-numpy==1.21.0
+numpy==1.19.2
 pandas==1.1.3
 psutil==5.7.2
 python-dateutil==2.8.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 Flask
 PyYAML
-boto3>=1.13.17
+boto3>=1.24.17
 coverage
 docker-compose
 flake8

--- a/test/unit/test_modules.py
+++ b/test/unit/test_modules.py
@@ -1,4 +1,12 @@
+import pandas as pd
+
+
 def test_pandas_version():
     import pandas as pd
     major, minor, patch = pd.__version__.split('.')
     assert major == '1'
+
+
+def test_pyarrow_to_parquet_conversion_regression_issue_106():
+    df = pd.DataFrame({'x': [1, 2]})
+    df.to_parquet('test.parquet', engine='pyarrow')


### PR DESCRIPTION
Issue #, if available:
* fixing https://github.com/aws/sagemaker-scikit-learn-container/issues/106
* Adding regression to catch the re occurrence of this issue. 
* Updating boto3 to 1.24.17 (to make it similar as 1.0 version) 
* Build failures during build
Description of changes:
* Numpy 1.2.x broke the integration with Pyarrow 1.0. Rolling back numpy version to 1.19.2
* Added Regression test
* Updated Docker build file to resolve build failures
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.