### PR TITLE
Update Miniconda and conda versions

### DIFF
--- a/docker/1.0-1/base/Dockerfile.cpu
+++ b/docker/1.0-1/base/Dockerfile.cpu
@@ -3,9 +3,10 @@ ARG UBUNTU_IMAGE_DIGEST=98706f0f213dbd440021993a82d2f70451a73698315370ae8615cc46
 
 FROM ubuntu:${UBUNTU_VERSION}@sha256:${UBUNTU_IMAGE_DIGEST}
 
-ARG MINICONDA_VERSION=4.11.0
+ARG MINICONDA_VERSION=4.12.0
+ARG CONDA_CHECKSUM=3190da6626f86eee8abf1b2fd7a5af492994eb2667357ee4243975cdbb175d7a
 ARG CONDA_PY_VERSION=38
-ARG CONDA_PKG_VERSION=4.9.0
+ARG CONDA_PKG_VERSION=4.13.0
 ARG PYTHON_VERSION=3.8.13
 ARG PYARROW_VERSION=1.0.0
 ARG MLIO_VERSION=0.7.0
@@ -61,8 +62,11 @@ RUN apt-get update && \
 
 RUN cd /tmp && \
     curl -L --output /tmp/Miniconda3.sh https://repo.anaconda.com/miniconda/Miniconda3-py${CONDA_PY_VERSION}_${MINICONDA_VERSION}-Linux-x86_64.sh && \
+    echo "${CONDA_CHECKSUM} /tmp/Miniconda3.sh" | sha256sum -c - && \
     bash /tmp/Miniconda3.sh -bfp /miniconda3 && \
-    rm /tmp/Miniconda3.sh
+    rm /tmp/Miniconda3.sh && \
+    # Remove this when we move to Miniconda version with conda package version 4.13.0+
+    rm -rf /miniconda3/pkgs/conda-4.12.0-py38h06a4308_0/info/test/*
 
 ENV PATH=/miniconda3/bin:${PATH}
 


### PR DESCRIPTION
There are a bunch of critical and high vulnerabilities in the current image, but those are all false positives. The impacted packages/package versions are not installed in the container, but package information is present within some test folder of conda installation. According to the comments in [this](https://github.com/AnacondaRecipes/conda-feedstock/pull/6) PR the test directory is redundant. Moreover these redundant files aren't included in conda versions 4.13.0 and up.

Most updated Miniconda version is 4.12.0 - https://repo.anaconda.com/miniconda/

**Testing**
* Enhanced scan on the new image shows no critical or high vulnerabilities.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
