### PR TITLE
Fix buildspec to push final image on PR merge

### DIFF
--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -44,13 +44,15 @@ phases:
     - echo Pushing the Docker image...
     - |
       case $CODEBUILD_WEBHOOK_EVENT in
-        PUSH)
+        PUSH | PULL_REQUEST_MERGED)
+          echo Pushing final image..
           docker push 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:$FRAMEWORK_VERSION-cpu-py3 | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
           ;;
-        PULL_REQUEST_MERGED | PULL_REQUEST_CREATED | PULL_REQUEST_UPDATED | PULL_REQUEST_REOPENED)
+        PULL_REQUEST_CREATED | PULL_REQUEST_UPDATED | PULL_REQUEST_REOPENED)
           # pushes test tag for manual verification, requires cleanup in ECR every once in a while though
           TEST_TAG=515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:$FRAMEWORK_VERSION-cpu-py3-test
           docker tag preprod-sklearn:$FRAMEWORK_VERSION-cpu-py3 ${TEST_TAG}
+          echo Pushing test image..
           docker push ${TEST_TAG} | grep -v -E "[0-9]{12}.dkr.ecr.\S+.amazonaws.com"
           ;;
         *)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ model-archiver==1.0.3
 multi-model-server==1.1.1
 numpy==1.19.2
 pandas==1.1.3
-protobuf==3.20.2
+protobuf==3.20.1
 psutil==5.7.2
 python-dateutil==2.8.1
 sagemaker-inference==1.2.0


### PR DESCRIPTION
Image created after a PR is merged has been getting tagged with "-test" suffix. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
