### PR TITLE
Update conda package version and buildspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+dist/
+build/
+src/sagemaker_sklearn_container.egg-info/
+.venv
+*~
+.tox
+__pycache__
+.coverage*
+.mypy_cache/

--- a/ci/buildspec.yml
+++ b/ci/buildspec.yml
@@ -23,4 +23,20 @@ phases:
     commands:
     - echo Build completed on `date`
     - echo Pushing the Docker image...
-    - docker push 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3
+    - |
+      case $CODEBUILD_WEBHOOK_EVENT in
+      PUSH | PULL_REQUEST_MERGED)
+          echo Pushing final image..
+          docker push 515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3
+          ;;
+        PULL_REQUEST_CREATED | PULL_REQUEST_UPDATED | PULL_REQUEST_REOPENED)
+          # pushes test tag for manual verification, requires cleanup in ECR every once in a while though
+          TEST_TAG=515193369038.dkr.ecr.us-west-2.amazonaws.com/sagemaker-scikit-learn:0.20.0-cpu-py3-test
+          docker tag preprod-sklearn:0.20.0-cpu-py3 ${TEST_TAG}
+          echo Pushing test image..
+          docker push ${TEST_TAG}
+          ;;
+        *)
+          echo Undefined behavior for webhook event type $CODEBUILD_WEBHOOK_EVENT
+          ;;
+      esac

--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -6,7 +6,7 @@ FROM ubuntu:${UBUNTU_VERSION}@sha256:${UBUNTU_IMAGE_DIGEST}
 ARG MINICONDA_VERSION=4.12.0
 ARG CONDA_CHECKSUM=4dc4214839c60b2f5eb3efbdee1ef5d9b45e74f2c09fcae6c8934a13f36ffc3e
 ARG CONDA_PY_VERSION=37
-ARG CONDA_PKG_VERSION=4.13.0
+ARG CONDA_PKG_VERSION=22.9.0
 ARG PYTHON_VERSION=3.7.10
 ARG PYARROW_VERSION=0.14.1
 ARG MLIO_VERSION=0.1
@@ -28,6 +28,9 @@ RUN cd /tmp && \
 ENV PATH=/miniconda3/bin:${PATH}
 
 RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
+    # Conda configuration see https://conda.io/projects/conda/en/latest/configuration.html
+    conda config --system --set auto_update_conda false && \
+    conda config --system --set show_channel_urls true && \
     echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
     conda install -c conda-forge python=${PYTHON_VERSION} && \
     conda update -y conda && \


### PR DESCRIPTION
The currently pinned conda version doesn't seem to work well with other packages explicitly marked in 0_20_0. Pinning the latest conda package version. 
Also the buildspec creates a final image irrespective of the Github event. Added logic to distinguish between code merge and other review events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
