### PR TITLE
Fix glog package version

### DIFF
--- a/docker/0.20.0/base/Dockerfile.cpu
+++ b/docker/0.20.0/base/Dockerfile.cpu
@@ -34,7 +34,7 @@ RUN echo "conda ${CONDA_PKG_VERSION}" >> /miniconda3/conda-meta/pinned && \
     echo "python ${PYTHON_VERSION}.*" >> /miniconda3/conda-meta/pinned && \
     conda install -c conda-forge python=${PYTHON_VERSION} && \
     conda update -y conda && \
-    conda install -c conda-forge pyarrow=${PYARROW_VERSION} && \
+    conda install -c conda-forge pyarrow=${PYARROW_VERSION} glog=0.5.0 && \
     conda install -c mlio -c conda-forge mlio-py=${MLIO_VERSION} && \
     conda install -c anaconda scipy && \
     conda install -c conda-forge tbb-devel=${TBB_VERSION}


### PR DESCRIPTION
Auto update of glog to higher version leads to training failures.

**Testing**

* Ran integ tests locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
