### PR TITLE
updating protobuf to 3.20.2 to address CVE-2022-1941

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ model-archiver==1.0.3
 multi-model-server==1.1.1
 numpy==1.19.2
 pandas==1.1.3
-protobuf==3.20.1
+protobuf==3.20.2
 psutil==5.7.2
 pyarrow==1.0.0
 python-dateutil==2.8.1


### PR DESCRIPTION
*Issue #, if available:*
[CVE-2022-1941](https://github.com/advisories/GHSA-8gq9-2x98-w8hf) is affecting a protobuf version we have, upgrading it to 3.20.2 will address the vulnerability.
*Description of changes:*
* Tested integ tests, all but version check test passed, which is expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
