### PR TITLE
Fix error with pyOpenSSL in arm v1.0-1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-boto3==1.24.17
-botocore==1.27.18
-cryptography==35.0.0
+boto3==1.28.15
+botocore==1.31.15
+cryptography==41.0.2
 Flask==1.1.1
 itsdangerous==2.0.1
 gunicorn==20.0.4
@@ -23,3 +23,4 @@ Werkzeug==0.15.6
 setuptools==65.5.1
 wheel==0.38.1
 numpy==1.24.1
+pyOpenSSL==23.2.0


### PR DESCRIPTION
*Issue #, if available:*
The below error was accrued during creating sagemaker endpoint. 
```
Traceback (most recent call last):
  File "/miniconda3/bin/serve", line 5, in <module>
    from sagemaker_sklearn_container.serving import serving_entrypoint
  File "/miniconda3/lib/python3.8/site-packages/sagemaker_sklearn_container/serving.py", line 18, in <module>
    from sagemaker_containers.beta.framework import (
  File "/miniconda3/lib/python3.8/site-packages/sagemaker_containers/beta/framework/__init__.py", line 21, in <module>
    from sagemaker_containers import _env as env
  File "/miniconda3/lib/python3.8/site-packages/sagemaker_containers/_env.py", line 27, in <module>
    import boto3
  File "/miniconda3/lib/python3.8/site-packages/boto3/__init__.py", line 17, in <module>
    from boto3.session import Session
  File "/miniconda3/lib/python3.8/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/miniconda3/lib/python3.8/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/miniconda3/lib/python3.8/site-packages/botocore/client.py", line 15, in <module>
    from botocore import waiter, xform_name
  File "/miniconda3/lib/python3.8/site-packages/botocore/waiter.py", line 18, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/miniconda3/lib/python3.8/site-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/miniconda3/lib/python3.8/site-packages/botocore/docs/service.py", line 14, in <module>
    from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
  File "/miniconda3/lib/python3.8/site-packages/botocore/docs/client.py", line 14, in <module>
    from botocore.docs.example import ResponseExampleDocumenter
  File "/miniconda3/lib/python3.8/site-packages/botocore/docs/example.py", line 13, in <module>
    from botocore.docs.shape import ShapeDocumenter
  File "/miniconda3/lib/python3.8/site-packages/botocore/docs/shape.py", line 19, in <module>
    from botocore.utils import is_json_value_header
  File "/miniconda3/lib/python3.8/site-packages/botocore/utils.py", line 34, in <module>
    import botocore.httpsession
  File "/miniconda3/lib/python3.8/site-packages/botocore/httpsession.py", line 41, in <module>
    from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext
  File "/miniconda3/lib/python3.8/site-packages/urllib3/contrib/pyopenssl.py", line 50, in <module>
    import OpenSSL.crypto
  File "/miniconda3/lib/python3.8/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import SSL, crypto
  File "/miniconda3/lib/python3.8/site-packages/OpenSSL/SSL.py", line 19, in <module>
    from OpenSSL.crypto import (
  File "/miniconda3/lib/python3.8/site-packages/OpenSSL/crypto.py", line 3263, in <module>
    utils.deprecated(
```
*Description of changes:*
Updated boto3, botocore, cryptography and pyOpenSSL


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
