### PR TITLE
Updating module import function from modules to importlib

### DIFF
--- a/src/sagemaker_sklearn_container/serving.py
+++ b/src/sagemaker_sklearn_container/serving.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import sagemaker_sklearn_container.exceptions as exc
 from sagemaker_containers.beta.framework import (
-    content_types, encoders, env, modules, transformer, worker, server)
+    content_types, encoders, env, transformer, worker, server)
 from sagemaker_sklearn_container.serving_mms import start_model_server
 
 logging.basicConfig(format='%(asctime)s %(levelname)s - %(name)s - %(message)s', level=logging.INFO)
@@ -117,7 +117,7 @@ def import_module(module_name, module_dir):
     try:  # if module_name already exists, use the existing one
         user_module = importlib.import_module(module_name)
     except ImportError:  # if the module has not been loaded, 'modules' downloads and installs it.
-        user_module = modules.import_module(module_dir, module_name)
+        user_module = importlib.import_module(module_dir, module_name)
     except Exception:  # this shouldn't happen
         logger.info("Encountered an unexpected error.")
         raise

--- a/src/sagemaker_sklearn_container/serving.py
+++ b/src/sagemaker_sklearn_container/serving.py
@@ -116,8 +116,6 @@ def import_module(module_name, module_dir):
 
     try:  # if module_name already exists, use the existing one
         user_module = importlib.import_module(module_name)
-    except ImportError:  # if the module has not been loaded, 'modules' downloads and installs it.
-        user_module = importlib.import_module(module_dir, module_name)
     except Exception:  # this shouldn't happen
         logger.info("Encountered an unexpected error.")
         raise


### PR DESCRIPTION
*Issue #, if available:* tt: D82164532

*Description of changes:*
This change addresses an issue where, by use of modules, every worker invoked installs the module. Switching to importlib then reduces this to a single install.

Ref : https://github.com/aws/sagemaker-xgboost-container/pull/381
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
