### PR TITLE
chore: trigger image rebuild for patching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,8 +232,7 @@ Contributing
 
 Please read
 `CONTRIBUTING.md <https://github.com/aws/sagemaker-scikit-learn-container/blob/master/CONTRIBUTING.md>`__
-for details on our code of conduct, and the process for submitting pull
-requests to us.
+for details on our code of conduct, and the process for submitting pull requests to us.
 
 License
 -------


### PR DESCRIPTION
Bumping jinja2 version to address vulnerabilities


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
