### PR TITLE
fix pip installation path

### DIFF
--- a/docker/1.2-1-1/final/Dockerfile.cpu
+++ b/docker/1.2-1-1/final/Dockerfile.cpu
@@ -8,10 +8,18 @@ COPY requirements.txt /requirements.txt
 RUN python -m pip install -r /requirements.txt && \
     rm /requirements.txt
 
+# Fix Python 3.10 compatibility for sagemaker-containers
+RUN python3 -c "import sys; sys.path.insert(0, '/miniconda3/lib/python3.10/site-packages'); \
+    import sagemaker_containers._mapping as m; \
+    import collections.abc; \
+    setattr(collections, 'Mapping', collections.abc.Mapping); \
+    exec(open('/miniconda3/lib/python3.10/site-packages/sagemaker_containers/_mapping.py').read().replace('collections.Mapping', 'collections.abc.Mapping'))" || \
+    sed -i 's/collections\.Mapping/collections.abc.Mapping/g' /miniconda3/lib/python3.10/site-packages/sagemaker_containers/_mapping.py
+
 COPY dist/sagemaker_sklearn_container-2.0-py3-none-any.whl /sagemaker_sklearn_container-2.0-py3-none-any.whl
 RUN rm /miniconda3/lib/python3.10/site-packages/**/REQUESTED && \
     rm /miniconda3/lib/python3.10/site-packages/**/direct_url.json
-RUN pip install --no-cache /sagemaker_sklearn_container-2.0-py3-none-any.whl && \
+RUN python3 -m pip install --no-cache /sagemaker_sklearn_container-2.0-py3-none-any.whl && \
     rm /sagemaker_sklearn_container-2.0-py3-none-any.whl
 
 ENV SAGEMAKER_TRAINING_MODULE sagemaker_sklearn_container.training:main


### PR DESCRIPTION
*Issue #, if available:*
sagemaker_sklearn_container is installed in /usr/local/lib/python3.8/dist-package, not in /miniconda3/lib/python3.10/site-packages in the container.

ll /usr/local/lib/python3.8/dist-packages|grep sagemaker_sklearn_container
drwxr-sr-x  4 root staff   4096 Sep 20 03:50 sagemaker_sklearn_container/
drwxr-sr-x  3 root staff   4096 Sep 20 03:50 sagemaker_sklearn_container-2.0.dist-info/

*Description of changes:*
- fix sagemaker_container in python3.10 in the container
- fix the sagemaker_sklearn_container installation path



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
