### PR TITLE
docs: direct new sklearn upgrades to AWS Deep Learning Containers repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,16 @@
 SageMaker Scikit-learn Container
 ===========================
 
+.. important::
+
+   **This repository is no longer actively maintained for new scikit-learn version upgrades.**
+
+   All future scikit-learn version upgrades and container releases are tracked in the
+   `AWS Deep Learning Containers <https://github.com/aws/deep-learning-containers>`__ repository
+   under `docker/sklearn <https://github.com/aws/deep-learning-containers/tree/master/docker/sklearn>`__.
+
+   This repository remains available as a source reference for the SageMaker scikit-learn serving framework code.
+
 SageMaker Scikit-learn Container is an open source library for making the
 Scikit-learn framework run on Amazon SageMaker.
 


### PR DESCRIPTION
Add README notice directing future sklearn version upgrades to the AWS Deep Learning Containers repository. Mirrors aws/sagemaker-xgboost-container#477.